### PR TITLE
google-api-core 2.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "google-api-core" %}
-{% set version = "2.2.2" %}
+{% set version = "2.6.1" %}
 
 package:
   name: {{ name|lower }}-split
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 97349cc18c2bb2415f64f1353a80273a289a61294ce3eb2f7ce682d251bdd997
+  sha256: 80cf307660624f84c754d68c3c6cd31780368019741d87e0c5df5ed84730ed26
 
 build:
   number: 0


### PR DESCRIPTION
Update google-api-core to 2.6.1