### PR TITLE
google-api-core 2.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "google-api-core" %}
-{% set version = "2.2.2" %}
+{% set version = "2.7.0" %}
 
 package:
   name: {{ name|lower }}-split
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 97349cc18c2bb2415f64f1353a80273a289a61294ce3eb2f7ce682d251bdd997
+  sha256: 53fde60b5589420df2c1b4c98674ecbc217226931b713247586f71f5c0458c38
 
 build:
   number: 0


### PR DESCRIPTION
Update google-api-core to 2.7.0