### PR TITLE
2.10.1 bump

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "google-api-core" %}
-{% set version = "2.2.2" %}
+{% set version = "2.10.1" %}
+{% set sha256 = "e16c15a11789bc5a3457afb2818a3540a03f341e6e710d7f9bbf6cde2ef4a7c8" %}
 
 package:
   name: {{ name|lower }}-split
@@ -7,12 +8,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 97349cc18c2bb2415f64f1353a80273a289a61294ce3eb2f7ce682d251bdd997
+  sha256: {{ sha256 }}
 
 build:
   number: 0
-  noarch: python
-  skip: True      # [s390x]
+  # noarch: python
+  skip: True      # [py<37]
 
 outputs:
   - name: {{ name }}
@@ -21,15 +22,20 @@ outputs:
       script: python -m pip install . -vv --no-deps
     requirements:
       host:
-        - python >=3.6
+        - python
+        - setuptools
+        - wheel
         - pip
       run:
-        - python >=3.6
-        - googleapis-common-protos >=1.52.0,<2.0dev
-        - protobuf >=3.12.0
-        - google-auth >=1.25.1,<3.0dev
+        - python
+        - googleapis-common-protos >=1.56.2,<2.0dev
+        - protobuf >=3.20.1
+        - google-auth >=1.25.0,<3.0dev
         - requests >=2.18.0,<3.0.0dev
-        - setuptools >=40.3.0
+      run_constrained:
+        - grpcio >=1.33.2,<2.0dev
+        - grpcio-status >=1.33.2,<2.0dev
+        - grpcio-gcp >= 0.2.2,<1.0dev
     test:
       requires:
         - pip
@@ -52,7 +58,7 @@ outputs:
         - google.api_core.retry
         - google.api_core.timeout
       commands:
-        - python -m pip check
+        - pip check
 
   - name: {{ name }}-grpc
     build:
@@ -81,7 +87,7 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage(name, exact=True) }}
-        - grpcio-gcp
+        - grpcio-gcp >=0.2.2,<1.0dev
     test:
       requires:
         - pip
@@ -126,24 +132,10 @@ about:
   description: |
     Core Library for Google Client Libraries
     -------------------------
-
-    This package does not include the grpc, grpcio-gcp or grpcgcp extra requirements.
-
-    This library is not meant to stand-alone. Instead it defines
-    common helpers used by all Google API clients. For more information, see the
-    [documentation](https://googleapis.dev/python/google-api-core/latest/index.html).
-
-    Supported Python Versions
-    -------------------------
-    Python >= 3.5
-
-    Deprecated Python Versions
-    --------------------------
-    Python == 2.7
-    - Python 2.7 support will be removed on January 1, 2020.
-    - protobuf does not support Visual C++ 2008, windows py27 package not available
-
+    This library is not meant to stand-alone. Instead it defines common helpers used by
+    all Google API clients. For more information, see the documentation.
   doc_url: https://googleapis.dev/python/google-api-core/latest/index.html
+  doc_source_url: https://github.com/googleapis/python-api-core/tree/main/docs
   dev_url: https://github.com/googleapis/python-api-core
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,6 @@ outputs:
   - name: {{ name }}-grpc
     build:
       # noarch: generic
-      skip: true  # [s390x]
     requirements:
       host:
         - python
@@ -87,7 +86,6 @@ outputs:
   - name: {{ name }}-grpcio-gcp
     build:
       # noarch: generic
-      skip: true  # [s390x]
     requirements:
       host:
         - python
@@ -112,7 +110,6 @@ outputs:
   - name: {{ name }}-grpcgcp
     build:
       # noarch: generic
-      skip: true  # [s390x]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "e16c15a11789bc5a3457afb2818a3540a03f341e6e710d7f9bbf6cde2ef4a7c8" %}
 
 package:
-  name: {{ name|lower }}-split
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -18,7 +18,6 @@ build:
 outputs:
   - name: {{ name }}
     build:
-      noarch: python
       script: python -m pip install . -vv --no-deps
     requirements:
       host:
@@ -35,7 +34,7 @@ outputs:
       run_constrained:
         - grpcio >=1.33.2,<2.0dev
         - grpcio-status >=1.33.2,<2.0dev
-        - grpcio-gcp >= 0.2.2,<1.0dev
+        - grpcio-gcp >=0.2.2,<1.0dev
     test:
       requires:
         - pip
@@ -65,6 +64,8 @@ outputs:
       # noarch: generic
       skip: true  # [s390x]
     requirements:
+      host:
+        - python
       run:
         - python
         - {{ pin_subpackage(name, exact=True) }}
@@ -76,7 +77,7 @@ outputs:
       imports:
         - google.api_core
       commands:
-        - python -m pip check
+        - pip check
     about:
       home: https://github.com/googleapis/python-api-core
       license: Apache-2.0
@@ -88,6 +89,8 @@ outputs:
       # noarch: generic
       skip: true  # [s390x]
     requirements:
+      host:
+        - python
       run:
         - python
         - {{ pin_subpackage(name, exact=True) }}
@@ -99,7 +102,7 @@ outputs:
         - google.api_core
         - grpc
       commands:
-        - python -m pip check
+        - pip check
     about:
       home: https://github.com/googleapis/python-api-core
       license: Apache-2.0
@@ -111,6 +114,8 @@ outputs:
       # noarch: generic
       skip: true  # [s390x]
     requirements:
+      host:
+        - python
       run:
         - python
         - {{ pin_subpackage(name + '-grpcio-gcp', exact=True) }}
@@ -122,7 +127,7 @@ outputs:
         - grpc
         - grpc_gcp
       commands:
-        - python -m pip check
+        - pip check
     about:
       home: https://github.com/googleapis/python-api-core
       license: Apache-2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,9 +62,11 @@ outputs:
 
   - name: {{ name }}-grpc
     build:
-      noarch: generic
+      # noarch: generic
+      skip: true  # [s390x]
     requirements:
       run:
+        - python
         - {{ pin_subpackage(name, exact=True) }}
         - grpcio >=1.33.2,<2.0dev
         - grpcio-status >=1.33.2,<2.0dev
@@ -83,9 +85,11 @@ outputs:
 
   - name: {{ name }}-grpcio-gcp
     build:
-      noarch: generic
+      # noarch: generic
+      skip: true  # [s390x]
     requirements:
       run:
+        - python
         - {{ pin_subpackage(name, exact=True) }}
         - grpcio-gcp >=0.2.2,<1.0dev
     test:
@@ -104,9 +108,11 @@ outputs:
 
   - name: {{ name }}-grpcgcp
     build:
-      noarch: generic
+      # noarch: generic
+      skip: true  # [s390x]
     requirements:
       run:
+        - python
         - {{ pin_subpackage(name + '-grpcio-gcp', exact=True) }}
     test:
       requires:


### PR DESCRIPTION
- Moved sha256 to top
- Removed noarch, restored s390x builds
- Updated python skip to 3.7
- Aligned dependencies to upstream setup.py
- Added setuptools and wheel to host dependencies
- Cleaned up metadata: reduced description, added doc_source_url
- Added python build dependencies to the metapackages so they build for the matrix

https://github.com/googleapis/python-api-core/blob/main/setup.py