### PR TITLE
update to 2.19.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
   - https://staging.continuum.io/prefect/fs/proto-plus-feedstock/pr15/facd425
+  - https://staging.continuum.io/prefect/fs/grpcio-status-feedstock/pr1/09446f6

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/proto-plus-feedstock/pr15/facd425
-  - https://staging.continuum.io/prefect/fs/grpcio-status-feedstock/pr1/09446f6
-  - https://staging.continuum.io/prefect/fs/grpcio-gcp-feedstock/pr2/94b775d

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/proto-plus-feedstock/pr15/facd425

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,4 @@
 channels:
   - https://staging.continuum.io/prefect/fs/proto-plus-feedstock/pr15/facd425
   - https://staging.continuum.io/prefect/fs/grpcio-status-feedstock/pr1/09446f6
+  - https://staging.continuum.io/prefect/fs/grpcio-gcp-feedstock/pr2/94b775d

--- a/recipe/bld_base.bat
+++ b/recipe/bld_base.bat
@@ -1,0 +1,2 @@
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
+if errorlevel 1 exit 1

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -xe
+
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,8 @@ build:
 
 outputs:
   - name: {{ name }}
-    script: python -m pip install . -vv --no-deps --no-build-isolation
+    build:
+      script: python -m pip install . -vv --no-deps --no-build-isolation
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "google-api-core" %}
-{% set version = "2.10.1" %}
-{% set sha256 = "e16c15a11789bc5a3457afb2818a3540a03f341e6e710d7f9bbf6cde2ef4a7c8" %}
+{% set version = "2.19.1" %}
+{% set sha256 = "f4695f1e3650b316a795108a76a1c416e6afb036199d1c1f1f110916df479ffd" %}
 
 package:
   name: {{ name }}
@@ -12,13 +12,11 @@ source:
 
 build:
   number: 0
-  # noarch: python
   skip: True      # [py<37]
 
 outputs:
   - name: {{ name }}
-    build:
-      script: python -m pip install . -vv --no-deps
+    script: python -m pip install . -vv --no-deps --no-build-isolation
     requirements:
       host:
         - python
@@ -28,12 +26,15 @@ outputs:
       run:
         - python
         - googleapis-common-protos >=1.56.2,<2.0dev
-        - protobuf >=3.20.1
-        - google-auth >=1.25.0,<3.0dev
+        - protobuf >=3.19.5,<6.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+        - proto-plus >=1.22.3,<2.0.0dev
+        - google-auth >=2.14.1,<3.0.dev0
         - requests >=2.18.0,<3.0.0dev
       run_constrained:
-        - grpcio >=1.33.2,<2.0dev
-        - grpcio-status >=1.33.2,<2.0dev
+        - grpcio >=1.33.2,<2.0dev # [py<311]
+        - grpcio >=1.49.1,<2.0dev # [py>=311]
+        - grpcio-status >=1.33.2,<2.0dev # [py<311]
+        - grpcio-status >=1.49.1,<2.0dev # [py>=311]
         - grpcio-gcp >=0.2.2,<1.0dev
     test:
       requires:
@@ -68,8 +69,10 @@ outputs:
       run:
         - python
         - {{ pin_subpackage(name, exact=True) }}
-        - grpcio >=1.33.2,<2.0dev
-        - grpcio-status >=1.33.2,<2.0dev
+        - grpcio >=1.33.2,<2.0dev # [py<311]
+        - grpcio >=1.49.1,<2.0dev # [py>=311]
+        - grpcio-status >=1.33.2,<2.0dev # [py<311]
+        - grpcio-status >=1.49.1,<2.0dev # [py>=311]
     test:
       requires:
         - pip
@@ -143,10 +146,13 @@ about:
     This library is not meant to stand-alone. Instead it defines common helpers used by
     all Google API clients. For more information, see the documentation.
   doc_url: https://googleapis.dev/python/google-api-core/latest/index.html
-  doc_source_url: https://github.com/googleapis/python-api-core/tree/main/docs
   dev_url: https://github.com/googleapis/python-api-core
 
 extra:
+  skip-lints:
+    - outputs_not_unique
+    - missing_python_build_tool
+    - missing_wheel
   feedstock-name: google-api-core
   recipe-maintainers:
     - BrentDorsey

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 outputs:
   - name: {{ name }}
     script: build_base.sh  # [unix]
-    script: build_base.bat  # [win]
+    script: bld_base.bat  # [win]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "f4695f1e3650b316a795108a76a1c416e6afb036199d1c1f1f110916df479ffd" %}
 
 package:
-  name: {{ name }}
+  name: {{ name }}-split
   version: {{ version }}
 
 source:
@@ -16,8 +16,8 @@ build:
 
 outputs:
   - name: {{ name }}
-    build:
-      script: python -m pip install . -vv --no-deps --no-build-isolation
+    script: build_base.sh  # [unix]
+    script: build_base.bat  # [win]
     requirements:
       host:
         - python
@@ -26,17 +26,17 @@ outputs:
         - pip
       run:
         - python
-        - googleapis-common-protos >=1.56.2,<2.0dev
+        - googleapis-common-protos >=1.56.2,<2.0dev0
         - protobuf >=3.19.5,<6.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
-        - proto-plus >=1.22.3,<2.0.0dev
+        - proto-plus >=1.22.3,<2.0.0dev0
         - google-auth >=2.14.1,<3.0.dev0
-        - requests >=2.18.0,<3.0.0dev
+        - requests >=2.18.0,<3.0.0dev0
       run_constrained:
-        - grpcio >=1.33.2,<2.0dev # [py<311]
-        - grpcio >=1.49.1,<2.0dev # [py>=311]
-        - grpcio-status >=1.33.2,<2.0dev # [py<311]
-        - grpcio-status >=1.49.1,<2.0dev # [py>=311]
-        - grpcio-gcp >=0.2.2,<1.0dev
+        - grpcio >=1.33.2,<2.0dev0 # [py<311]
+        - grpcio >=1.49.1,<2.0dev0 # [py>=311]
+        - grpcio-status >=1.33.2,<2.0dev0 # [py<311]
+        - grpcio-status >=1.49.1,<2.0dev0 # [py>=311]
+        - grpcio-gcp >=0.2.2,<1.0dev0
     test:
       requires:
         - pip
@@ -70,10 +70,10 @@ outputs:
       run:
         - python
         - {{ pin_subpackage(name, exact=True) }}
-        - grpcio >=1.33.2,<2.0dev # [py<311]
-        - grpcio >=1.49.1,<2.0dev # [py>=311]
-        - grpcio-status >=1.33.2,<2.0dev # [py<311]
-        - grpcio-status >=1.49.1,<2.0dev # [py>=311]
+        - grpcio >=1.33.2,<2.0dev0 # [py<311]
+        - grpcio >=1.49.1,<2.0dev0 # [py>=311]
+        - grpcio-status >=1.33.2,<2.0dev0 # [py<311]
+        - grpcio-status >=1.49.1,<2.0dev0 # [py>=311]
     test:
       requires:
         - pip
@@ -96,7 +96,7 @@ outputs:
       run:
         - python
         - {{ pin_subpackage(name, exact=True) }}
-        - grpcio-gcp >=0.2.2,<1.0dev
+        - grpcio-gcp >=0.2.2,<1.0dev0
     test:
       requires:
         - pip
@@ -151,7 +151,6 @@ about:
 
 extra:
   skip-lints:
-    - outputs_not_unique
     - missing_python_build_tool
     - missing_wheel
   feedstock-name: google-api-core


### PR DESCRIPTION
google-api-core 2.19.1

**Destination channel:** main 

### Links

- https://anaconda.atlassian.net/browse/PKG-2706
- https://github.com/googleapis/python-api-core
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/proto-plus-feedstock/pull/15
  - https://github.com/AnacondaRecipes/grpcio-gcp-feedstock/pull/2
  - https://github.com/AnacondaRecipes/grpcio-status-feedstock/pull/1
### Explanation of changes:

- update for newer protobuf
