### PR TITLE
v2.24.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,5 +2,4 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/grpcio-gcp-feedstock/pr3/837452e
   - https://staging.continuum.io/prefect/fs/grpcio-status-feedstock/pr2/0f2d3e0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/grpcio-status-feedstock/pr2/0f2d3e0
-  - https://staging.continuum.io/prefect/fs/grpcio-gcp-feedstock/pr4/ac7a5bb

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/grpcio-gcp-feedstock/pr3/837452e

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,4 @@ build_env_vars:
 
 channels:
   - https://staging.continuum.io/prefect/fs/grpcio-status-feedstock/pr2/0f2d3e0
+  - https://staging.continuum.io/prefect/fs/grpcio-gcp-feedstock/pr4/ac7a5bb

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,4 @@ build_env_vars:
 
 channels:
   - https://staging.continuum.io/prefect/fs/grpcio-gcp-feedstock/pr3/837452e
+  - https://staging.continuum.io/prefect/fs/grpcio-status-feedstock/pr2/0f2d3e0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,8 +63,6 @@ outputs:
         - pip check
 
   - name: {{ name }}-grpc
-    build:
-      skip: True  # [py>312]
     requirements:
       host:
         - python
@@ -90,7 +88,8 @@ outputs:
 
   - name: {{ name }}-grpcio-gcp
     build:
-      # grpc-gcp-python hasn't been updated in 7+ years. 
+      # Support for grpcio-gcp is deprecated ast of January 1, 2024
+      # https://github.com/googleapis/python-api-core/blob/42e8b6e6f426cab749b34906529e8aaf3f133d75/google/api_core/grpc_helpers.py#L39-L45
       skip: true
     requirements:
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ outputs:
 
   - name: {{ name }}-grpc
     build:
-      # noarch: generic
+      skip: True  # [py>312]
     requirements:
       host:
         - python
@@ -90,7 +90,7 @@ outputs:
 
   - name: {{ name }}-grpcio-gcp
     build:
-      # noarch: generic
+      skip: True  # [py>312]
     requirements:
       host:
         - python
@@ -114,7 +114,7 @@ outputs:
 
   - name: {{ name }}-grpcgcp
     build:
-      # noarch: generic
+      skip: True  # [py>312]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ outputs:
         - grpcio-status >=1.33.2,<2.0.0  # [py<311]
         - grpcio-status >=1.49.1,<2.0.0  # [py>=311]
         - grpcio-gcp >=0.2.2,<1.0.0
-        - aiohttp >=2.35.0,<3.0.dev0
+        - aiohttp >=3.6.2,<4.0.0.dev0
     test:
       requires:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
 {% set name = "google-api-core" %}
-{% set version = "2.19.1" %}
-{% set sha256 = "f4695f1e3650b316a795108a76a1c416e6afb036199d1c1f1f110916df479ffd" %}
+{% set version = "2.24.2" %}
 
 package:
   name: {{ name }}-split
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace("-", "_") }}-{{ version }}.tar.gz
+  sha256: 81718493daf06d96d6bc76a91c23874dbf2fac0adbbf542831b805ee6e974696
 
 build:
   number: 0
@@ -27,8 +26,9 @@ outputs:
       run:
         - python
         - googleapis-common-protos >=1.56.2,<2.0dev0
-        - protobuf >=3.19.5,<6.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+        - protobuf >=3.19.5,<7.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
         - proto-plus >=1.22.3,<2.0.0dev0
+        - proto-plus >=1.25.0,<2.0.0dev0  # [py>=313]
         - google-auth >=2.14.1,<3.0.dev0
         - requests >=2.18.0,<3.0.0dev0
       run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: True      # [py<37]
+  skip: True  # [py<37]
+  skip: True  # [linux and s390x]
 
 outputs:
   - name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,7 +90,8 @@ outputs:
 
   - name: {{ name }}-grpcio-gcp
     build:
-      skip: True  # [py>312]
+      # grpc-gcp-python hasn't been updated in 7+ years. 
+      skip: true
     requirements:
       host:
         - python
@@ -98,6 +99,8 @@ outputs:
         - python
         - {{ pin_subpackage(name, exact=True) }}
         - grpcio-gcp >=0.2.2,<1.0dev0
+      run_constrained:
+        - protobuf >=3.6.1,<3.21
     test:
       requires:
         - pip
@@ -114,7 +117,7 @@ outputs:
 
   - name: {{ name }}-grpcgcp
     build:
-      skip: True  # [py>312]
+      skip: true
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,18 +26,19 @@ outputs:
         - pip
       run:
         - python
-        - googleapis-common-protos >=1.56.2,<2.0dev0
-        - protobuf >=3.19.5,<7.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
-        - proto-plus >=1.22.3,<2.0.0dev0
-        - proto-plus >=1.25.0,<2.0.0dev0  # [py>=313]
-        - google-auth >=2.14.1,<3.0.dev0
-        - requests >=2.18.0,<3.0.0dev0
+        - googleapis-common-protos >=1.56.2,<2.0.0
+        - protobuf >=3.19.5,<7.0.0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+        - proto-plus >=1.22.3,<2.0.0
+        - proto-plus >=1.25.0,<2.0.0  # [py>=313]
+        - google-auth >=2.14.1,<3.0.0
+        - requests >=2.18.0,<3.0.0
       run_constrained:
-        - grpcio >=1.33.2,<2.0dev0 # [py<311]
-        - grpcio >=1.49.1,<2.0dev0 # [py>=311]
-        - grpcio-status >=1.33.2,<2.0dev0 # [py<311]
-        - grpcio-status >=1.49.1,<2.0dev0 # [py>=311]
-        - grpcio-gcp >=0.2.2,<1.0dev0
+        - grpcio >=1.33.2,<2.0dev  # [py<311]
+        - grpcio >=1.49.1,<2.0dev  # [py>=311]
+        - grpcio-status >=1.33.2,<2.0.0  # [py<311]
+        - grpcio-status >=1.49.1,<2.0.0  # [py>=311]
+        - grpcio-gcp >=0.2.2,<1.0.0
+        - aiohttp >=2.35.0,<3.0.dev0
     test:
       requires:
         - pip


### PR DESCRIPTION
google-api-core v2.24.2

**Destination channel:**  defaults

### Links

- [PKG-7498](https://anaconda.atlassian.net/browse/PKG-7498) 
- [Upstream repository](https://github.com/googleapis/python-api-core/tree/v2.24.2)

### Explanation of changes:

- Bump version and SHA
- Update pinnings. 
- Skip s390x
- Skip outputs that rely on `grpcio-gcp` which is no longer active. 


[PKG-7498]: https://anaconda.atlassian.net/browse/PKG-7498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ