### PR TITLE
google-api-core 2.26.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "google-api-core" %}
-{% set version = "2.24.2" %}
+{% set version = "2.26.0" %}
 
 package:
   name: {{ name }}-split
@@ -7,12 +7,11 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace("-", "_") }}-{{ version }}.tar.gz
-  sha256: 81718493daf06d96d6bc76a91c23874dbf2fac0adbbf542831b805ee6e974696
+  sha256: e6e6d78bd6cf757f4aee41dcc85b07f485fbb069d5daa3afb126defba1e91a62
 
 build:
   number: 0
   skip: True  # [py<37]
-  skip: True  # [linux and s390x]
 
 outputs:
   - name: {{ name }}


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-10022](https://anaconda.atlassian.net/browse/PKG-10022)
- [Upstream repository](https://github.com/googleapis/python-api-core/tree/v2.26.0)
- [Upstream changelog/diff](https://github.com/googleapis/python-api-core/blob/v2.26.0/CHANGELOG.md)
- https://package-build.anaconda.com/v1/graph/02a6c15c-b95a-4d13-86ee-5c01c55eb1f7

### Explanation of changes:

- New version
- Remove deprecated s390x skip


[PKG-10022]: https://anaconda.atlassian.net/browse/PKG-10022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ